### PR TITLE
Proposal to change Yodaspeak to class

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or install it yourself as:
   require 'yodaspeak'
 
   yoda = Yodaspeak.new("API_KEY")
-  Yoda.speak("You must seek advice.")
+  yoda.speak("You must seek advice.")
   #=> "Seek advice, you must.  Yeesssssss."
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,8 @@ Or install it yourself as:
 ```ruby
   require 'yodaspeak'
 
-
-  Yodaspeak.credentials("API_KEY")
-
-  Yodaspeak.speak("You must seek advice.")
-  #=> Will return an Unirest Object
-
-  Yodaspeak.speak("You must seek advice.").body
+  yoda = Yodaspeak.new("API_KEY")
+  Yoda.speak("You must seek advice.")
   #=> "Seek advice, you must.  Yeesssssss."
 ```
 

--- a/lib/yodaspeak.rb
+++ b/lib/yodaspeak.rb
@@ -1,25 +1,24 @@
 require "yodaspeak/version"
 require 'unirest'
 
-module Yodaspeak
+class Yodaspeak
+  ENDPOINT = "https://yoda.p.mashape.com/yoda".freeze
 
-  module Default
-    @@api_endpoint = "https://yoda.p.mashape.com/yoda?sentence="
+  attr_writer :api_key
+
+  def initialize(api_key = nil)
+    @api_key = api_key
   end
 
-  def self.speak words
-    include Default
-    @api_endpoint = @@api_endpoint
-    yodaish = words.split(" ").join("+")
-    @api_endpoint += yodaish
-    Unirest.get(@api_endpoint, headers: @headers)
+  def speak(words)
+    words.gsub!(" ", "+")
+    Unirest.get("#{ENDPOINT}?sentence=#{words}", headers: headers).body
   end
 
-  def self.credentials api_key
-    @headers= {
-      "X-Mashape-Key" => api_key,
-      "Accept" => "text/plain"
+  def headers
+    {
+      "X-Mashape-Key" => @api_key,
+      "Accept"        => "text/plain"
     }
   end
-
 end

--- a/lib/yodaspeak.rb
+++ b/lib/yodaspeak.rb
@@ -15,6 +15,8 @@ class Yodaspeak
     Unirest.get("#{ENDPOINT}?sentence=#{words}", headers: headers).body
   end
 
+  private
+
   def headers
     {
       "X-Mashape-Key" => @api_key,

--- a/lib/yodaspeak/version.rb
+++ b/lib/yodaspeak/version.rb
@@ -1,3 +1,3 @@
 class Yodaspeak
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/lib/yodaspeak/version.rb
+++ b/lib/yodaspeak/version.rb
@@ -1,3 +1,3 @@
-module Yodaspeak
+class Yodaspeak
   VERSION = "0.1.2"
 end

--- a/spec/cassettes/Yodaspeak/_speak/1_2_1.yml
+++ b/spec/cassettes/Yodaspeak/_speak/1_2_1.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://yoda.p.mashape.com/yoda?sentence=I%20will%20be%20a%20man%20like%20yoda.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip
+      X-Mashape-Key:
+      - VzHoZcrJ2JmshtxppwEzlfzaRW60p1Syat9jsnglzJHljoAwf5
+      User-Agent:
+      - unirest-ruby/1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Sat, 16 Jan 2016 16:48:48 GMT
+      Server:
+      - Mashape/5.0.6
+      Via:
+      - 1.1 vegur
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '38'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: Man like yoda, will I be.  Yeesssssss.
+    http_version: 
+  recorded_at: Sat, 16 Jan 2016 16:48:48 GMT
+recorded_with: VCR 3.0.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,8 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'yodaspeak'
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end

--- a/spec/yodaspeak_spec.rb
+++ b/spec/yodaspeak_spec.rb
@@ -5,4 +5,13 @@ describe Yodaspeak do
     expect(Yodaspeak::VERSION).not_to be nil
   end
 
+  describe '#headers' do
+    subject { yodaspeak.instance_eval { headers } }
+    let(:yodaspeak) { Yodaspeak.new("API_KEY") }
+
+    it "gets headers" do
+      is_expected.to include "X-Mashape-Key" => "API_KEY",
+                             "Accept"        => "text/plain"
+    end
+  end
 end

--- a/spec/yodaspeak_spec.rb
+++ b/spec/yodaspeak_spec.rb
@@ -5,6 +5,16 @@ describe Yodaspeak do
     expect(Yodaspeak::VERSION).not_to be nil
   end
 
+  describe '#speak', :vcr do
+    subject { yodaspeak.speak("I will be a man like yoda.") }
+    let(:yodaspeak) { Yodaspeak.new(api_key) }
+    let(:api_key) { "VzHoZcrJ2JmshtxppwEzlfzaRW60p1Syat9jsnglzJHljoAwf5" }
+
+    it "returns yodaish" do
+      is_expected.to eq "Man like yoda, will I be.  Yeesssssss."
+    end
+  end
+
   describe '#headers' do
     subject { yodaspeak.instance_eval { headers } }
     let(:yodaspeak) { Yodaspeak.new("API_KEY") }

--- a/yodaspeak.gemspec
+++ b/yodaspeak.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
Hi! yodaspeak.co.uk and this gem is so nice. :dancers: 
But, I think it's better that you change `Yodaspeak` to class.
## Changes
- change`Yodaspeak` from module to class (or It might be better to add class `Yodaspeak::Yoda` leaving `Yodaspeak` as module. What do you think?)
  - for creating instance
- `#speak` returns body string instead of Unirest object
  - because I have expected just a string of result
- add some tests :octocat: 
  - using vcr to mock api responses

thank you :smiley_cat: 
